### PR TITLE
Fix/context fix for build

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -6,7 +6,6 @@
 import React from 'react';
 import AppContainer from './src/components/app-container';
 
-// You can delete this file if you're not using it
 export const wrapRootElement = ({ element }) => (
   <AppContainer>{element}</AppContainer>
 );

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -3,5 +3,9 @@
  *
  * See: https://www.gatsbyjs.org/docs/ssr-apis/
  */
+import React from 'react';
+import AppContainer from './src/components/app-container';
 
-// You can delete this file if you're not using it
+export const wrapRootElement = ({ element }) => (
+  <AppContainer>{element}</AppContainer>
+);


### PR DESCRIPTION
Hey Jason! Just thought I'd do this quick PR to help out another soul like myself who happened upon your context work and tried implementing it the same way. I kept running into an error when running `gatsby build` where destructuring from the context wouldn't work. In the case of your repo, you get "WebpackError: TypeError: Cannot read property 'comment' of undefined". This is solved by also adding the same code from gatsby-browser.js to gatsby-ssr.js.

Is this the correct fix? Thanks!